### PR TITLE
fix: use virtual environment to install pygit2 (PEP 668)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,9 @@ runs:
   using: "composite"
   steps:
     - name: Install Python Dependencies
-      run: python3 -m pip install pygit2
+      env:
+        VENV_PATH: /tmp/check-action-venv
+      run: python3 -m venv "$VENV_PATH" && "$VENV_PATH/bin/pip" install pygit2
       shell: bash
 
     - name: Check the changed files (wrapper)
@@ -37,6 +39,7 @@ runs:
       env:
         ACTION_REF: ${{ github.action_ref }}
         ACTION_SHA: ${{ github.action_sha }}
+        VENV_PATH: /tmp/check-action-venv
       run: |
         # Check if curl is installed, if not install it
         if ! command -v curl &> /dev/null; then
@@ -86,5 +89,5 @@ runs:
         if [ "${{ inputs.check_all_files }}" == "true" ]; then
             optional_flags+=" -caf"
         fi
-        echo "changed-files=$(python3 /tmp/check_changed_files.py -cl '${{ inputs.checked_location }}' $optional_flags)" >> "$GITHUB_OUTPUT"
+        echo "changed-files=$("$VENV_PATH/bin/python3" /tmp/check_changed_files.py -cl '${{ inputs.checked_location }}' $optional_flags)" >> "$GITHUB_OUTPUT"
       shell: bash


### PR DESCRIPTION
- Use a virtual environment to install pygit2